### PR TITLE
add testnet support for bip84

### DIFF
--- a/Sources/HdWalletKit/HDExtendedKeyVersion.swift
+++ b/Sources/HdWalletKit/HDExtendedKeyVersion.swift
@@ -12,8 +12,10 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
     case Ltub = 0x019da462
     case Mtpv = 0x01b26792
     case Mtub = 0x01b26ef6
+    case vprv = 0x045f18bc
+    case vpub = 0x045f1cf6
 
-    public init(purpose: Purpose, coinType: ExtendedKeyCoinType, isPrivate: Bool = true) throws {
+    public init(purpose: Purpose, coinType: ExtendedKeyCoinType, isPrivate: Bool = true, isTestNet: Bool) throws {
         switch purpose {
         case .bip44:
             switch coinType {
@@ -26,7 +28,11 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
             case .litecoin: self = isPrivate ? .Mtpv : .Mtub
             }
         case .bip84:
-            self = isPrivate ? .zprv : .zpub
+            if isTestNet {
+                self = isPrivate ? .vprv : .vpub
+            } else {
+                self = isPrivate ? .zprv : .zpub
+            }
         case .bip86:
             self = isPrivate ? .xprv : .xpub
         }
@@ -52,6 +58,8 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
         case .Ltub: return "Ltub"
         case .Mtpv: return "Mtpv"
         case .Mtub: return "Mtub"
+        case .vprv: return "vprv"
+        case .vpub: return "vpub"
         }
     }
 
@@ -60,14 +68,14 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
         case .xprv, .xpub: return [.bip44, .bip86]
         case .Ltpv, .Ltub: return [.bip44]
         case .yprv, .ypub, .Mtpv, .Mtub: return [.bip49]
-        case .zprv, .zpub: return [.bip84]
+        case .zprv, .zpub, .vprv, .vpub: return [.bip84]
         }
     }
 
     public var coinTypes: [ExtendedKeyCoinType] {
         switch self {
         case .xprv, .xpub, .zprv, .zpub: return [.bitcoin, .litecoin]
-        case .yprv, .ypub: return [.bitcoin]
+        case .yprv, .ypub, .vprv, .vpub: return [.bitcoin]
         case .Ltpv, .Ltub, .Mtpv, .Mtub: return [.litecoin]
         }
     }
@@ -79,13 +87,14 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
         case .zprv: return .zpub
         case .Ltpv: return .Ltub
         case .Mtpv: return .Mtub
+        case .vprv: return .vpub
         default: return self
         }
     }
 
     public var isPublic: Bool {
         switch self {
-        case .xpub, .ypub, .zpub, .Ltub, .Mtub: return true
+        case .xpub, .ypub, .zpub, .Ltub, .Mtub, .vpub: return true
         default: return false
         }
     }

--- a/Sources/HdWalletKit/HDExtendedKeyVersion.swift
+++ b/Sources/HdWalletKit/HDExtendedKeyVersion.swift
@@ -14,13 +14,19 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
     case Mtub = 0x01b26ef6
     case vprv = 0x045f18bc
     case vpub = 0x045f1cf6
+    case tpub = 0x043587cf
+    case tprv = 0x04358394
 
     public init(purpose: Purpose, coinType: ExtendedKeyCoinType, isPrivate: Bool = true, isTestNet: Bool) throws {
         switch purpose {
         case .bip44:
-            switch coinType {
-            case .bitcoin: self = isPrivate ? .xprv : .xpub
-            case .litecoin: self = isPrivate ? .Ltpv : .Ltub
+            if isTestNet {
+                self = isPrivate ? .tprv : .tpub
+            } else {
+                switch coinType {
+                case .bitcoin: self = isPrivate ? .xprv : .xpub
+                case .litecoin: self = isPrivate ? .Ltpv : .Ltub
+                }
             }
         case .bip49:
             switch coinType {
@@ -60,13 +66,15 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
         case .Mtub: return "Mtub"
         case .vprv: return "vprv"
         case .vpub: return "vpub"
+        case .tprv: return "tprv"
+        case .tpub: return "tpub"
         }
     }
 
     public var purposes: [Purpose] {
         switch self {
         case .xprv, .xpub: return [.bip44, .bip86]
-        case .Ltpv, .Ltub: return [.bip44]
+        case .Ltpv, .Ltub, .tprv, .tpub: return [.bip44]
         case .yprv, .ypub, .Mtpv, .Mtub: return [.bip49]
         case .zprv, .zpub, .vprv, .vpub: return [.bip84]
         }
@@ -75,7 +83,7 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
     public var coinTypes: [ExtendedKeyCoinType] {
         switch self {
         case .xprv, .xpub, .zprv, .zpub: return [.bitcoin, .litecoin]
-        case .yprv, .ypub, .vprv, .vpub: return [.bitcoin]
+        case .yprv, .ypub, .vprv, .vpub, .tprv, .tpub: return [.bitcoin]
         case .Ltpv, .Ltub, .Mtpv, .Mtub: return [.litecoin]
         }
     }
@@ -94,7 +102,7 @@ public enum HDExtendedKeyVersion: UInt32, CaseIterable {
 
     public var isPublic: Bool {
         switch self {
-        case .xpub, .ypub, .zpub, .Ltub, .Mtub, .vpub: return true
+        case .xpub, .ypub, .zpub, .Ltub, .Mtub, .vpub, .tpub: return true
         default: return false
         }
     }


### PR DESCRIPTION
Currently - for Testnet HDWalletKit uses incorrect prefixes.
Added prefix for bip84 testnet to fetch correct balance on test and send signed transaction outside of BitcoinKit for read only wallet.